### PR TITLE
Update wrong activity link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## Addons Activity for Mozilla Campus Clubs program
 
-[Check the activity in this link](https://mozillacampusclubs.github.io/becomeVRRockstar/) for introducing your club members into WebExtensions Addons
+[Check the activity in this link](https://mozillacampusclubs.github.io/teach-how-to-build-addons/) for introducing your club members into WebExtensions Addons
 
 
 ## Credits


### PR DESCRIPTION
The activity link for leaning how to make web extension is broken. I have updated it to right url address.